### PR TITLE
Generics implementation

### DIFF
--- a/Example.playground/Contents.swift
+++ b/Example.playground/Contents.swift
@@ -6,14 +6,17 @@ import Stateful
 
 class StateMachineExamples {
 
-    enum EventType: String {
+    typealias TransitionDefault = Transition<StateType, EventType>
+    typealias StateMachineDefault = StateMachine<StateType, EventType>
+
+    enum EventType {
         case start
         case stop
         case execute
         case complete
     }
     
-    enum StateType: String {
+    enum StateType {
         case idle
         case started
         case running
@@ -23,48 +26,49 @@ class StateMachineExamples {
     func runSampleStateMachine() {
         
         let dispatchQueue = DispatchQueue(label: "com.albertodebortoli.someSerialCallbackQueue")
-        let stateMachine = StateMachine(initialState: "idle", callbackQueue: dispatchQueue)
+        let stateMachine = StateMachineDefault(initialState: .idle,
+                                               callbackQueue: dispatchQueue)
         stateMachine.enableLogging = true
         
-        let t1 = Transition(with: EventType.start.rawValue,
-                            from: StateType.idle.rawValue,
-                            to: StateType.started.rawValue,
+        let t1 = TransitionDefault(with: EventType.start,
+                            from: StateType.idle,
+                            to: StateType.started,
                             preBlock: {
                                 print("Going to move from \(StateType.idle) to \(StateType.started)!")
         }, postBlock: {
             print("Just moved from \(StateType.idle) to \(StateType.started)!")
         })
         
-        let t2 = Transition(with: EventType.stop.rawValue,
-                            from: StateType.started.rawValue,
-                            to: StateType.idle.rawValue,
+        let t2 = TransitionDefault(with: .stop,
+                            from: .started,
+                            to: .idle,
                             preBlock: {
                                 print("Going to move from \(StateType.started) to Idle!")
         }, postBlock: {
             print("Just moved from \(StateType.started) to \(StateType.idle)!")
         })
         
-        let t3 = Transition(with: EventType.execute.rawValue,
-                            from: StateType.started.rawValue,
-                            to: StateType.running.rawValue,
+        let t3 = TransitionDefault(with: .execute,
+                            from: .started,
+                            to: .running,
                             preBlock: {
                                 print("Going to move from \(StateType.started) to \(StateType.running)!")
         }, postBlock: {
             print("Just moved from \(StateType.started) to \(StateType.running)!")
         })
         
-        let t4 = Transition(with: EventType.stop.rawValue,
-                            from: StateType.running.rawValue,
-                            to: StateType.idle.rawValue,
+        let t4 = TransitionDefault(with: .stop,
+                            from: .running,
+                            to: .idle,
                             preBlock: {
                                 print("Going to move from \(StateType.running) to \(StateType.idle)!")
         }, postBlock: {
             print("Just moved from \(StateType.running) to \(StateType.idle)!")
         })
         
-        let t5 = Transition(with: EventType.complete.rawValue,
-                            from: StateType.running.rawValue,
-                            to: StateType.completed.rawValue,
+        let t5 = TransitionDefault(with: .complete,
+                            from: .running,
+                            to: .completed,
                             preBlock: {
                                 print("Going to move from \(StateType.running) to \(StateType.completed)!")
         }, postBlock: {
@@ -86,20 +90,20 @@ class StateMachineExamples {
             }
         }
         
-        stateMachine.process(event: "start", callback: callback)
-        stateMachine.process(event: "start", callback: callback)
-        stateMachine.process(event: "stop")
-        stateMachine.process(event: "start")
-        stateMachine.process(event: "stop")
-        stateMachine.process(event: "start")
-        stateMachine.process(event: "execute")
-        stateMachine.process(event: "start")
-        stateMachine.process(event: "stop")
-        stateMachine.process(event: "start")
-        stateMachine.process(event: "execute")
-        stateMachine.process(event: "complete")
-        stateMachine.process(event: "start")
-        stateMachine.process(event: "stop")
+        stateMachine.process(event: .start, callback: callback)
+        stateMachine.process(event: .start, callback: callback)
+        stateMachine.process(event: .stop)
+        stateMachine.process(event: .start)
+        stateMachine.process(event: .stop)
+        stateMachine.process(event: .start)
+        stateMachine.process(event: .execute)
+        stateMachine.process(event: .start)
+        stateMachine.process(event: .stop)
+        stateMachine.process(event: .start)
+        stateMachine.process(event: .execute)
+        stateMachine.process(event: .complete)
+        stateMachine.process(event: .start)
+        stateMachine.process(event: .stop)
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Stateful is a minimalistic, thread-safe, non-boilerplate and super easy to use s
 - define the events and statuses you need. E.g.:
 
 ```swift
-enum EventType: String {
+enum EventType {
     case start
     case pause
 }
 
-enum StateType: String {
+enum StateType {
     case idle
     case started
 }
@@ -28,26 +28,26 @@ enum StateType: String {
 - create a state machine with the initial state (you might want to retain it in a property)
 
 ```swift
-let stateMachine = StateMachine(initialState: StateType.idle.rawValue)
+let stateMachine = StateMachine<StateType, EventType>(initialState: StateType.idle)
 ```
 
 `StateMachine` will use the main queue to execute the transition pre and post blocks but you can optionally provide a custom one.
 
 ```swift
 let dispatchQueue = DispatchQueue(label: "com.albertodebortoli.someSerialCallbackQueue")
-let stateMachine = StateMachine(initialState: StateType.idle.rawValue, callbackQueue: dispatchQueue)
+let stateMachine = StateMachine<StateType, EventType>(initialState: StateType.idle, callbackQueue: dispatchQueue)
 ```
 
 - create transitions and add them to the state machine (the state machine will automatically recognize the new statuses)
 
 ```swift
-let t1 = Transition(with: EventType.start.rawValue,
-                    fromState: StateType.idle.rawValue,
-                    toState: StateType.started.rawValue)
+let t1 = Transition<StateType, EventType>(with: EventType.start,
+                    fromState: StateType.idle,
+                    toState: StateType.started)
                     
-let t2 = Transition(with: EventType.pause.rawValue,
-                    from: StateType.started.rawValue,
-                    to: StateType.idle.rawValue,
+let t2 = Transition<StateType, EventType>(with: EventType.pause,
+                    from: StateType.started,
+                    to: StateType.idle,
                     preBlock: {
                         print("Going to move from \(StateType.started) to \(StateType.idle)!")
                     }, postBlock: {
@@ -61,8 +61,8 @@ stateMachine.add(transition: t2)
 - process events like so
 
 ```swift
-stateMachine.process(event: EventType.start.rawValue)
-stateMachine.process(event: EventType.pause.rawValue, callback: { result in
+stateMachine.process(event: EventType.start)
+stateMachine.process(event: EventType.pause, callback: { result in
     switch result {
     case .success:
         print("Event 'pause' was processed")

--- a/Stateful/Classes/StateMachine.swift
+++ b/Stateful/Classes/StateMachine.swift
@@ -7,32 +7,32 @@
 
 import Foundation
 
-final public class StateMachine {
-    
+final public class StateMachine<State: Hashable, Event: Hashable> {
+
     public var enableLogging: Bool = false
-    public var currentState: String {
+    public var currentState: State {
         return {
             workingQueue.sync {
                 return internalCurrentState
             }
-        }()
+            }()
     }
-    
-    private var internalCurrentState: String
-    private var transitionsByEvent: [String : [Transition]] = [:]
-    
+
+    private var internalCurrentState: State
+    private var transitionsByEvent: [Event : [Transition<State, Event>]] = [:]
+
     private let lockQueue: DispatchQueue
     private let workingQueue: DispatchQueue
     private let callbackQueue: DispatchQueue
-    
-    public init(initialState: String, callbackQueue: DispatchQueue? = nil) {
+
+    public init(initialState: State, callbackQueue: DispatchQueue? = nil) {
         self.internalCurrentState = initialState
         self.lockQueue = DispatchQueue(label: "com.albertodebortoli.statemachine.queue.lock")
         self.workingQueue = DispatchQueue(label: "com.albertodebortoli.statemachine.queue.working")
-        self.callbackQueue = callbackQueue ?? DispatchQueue.main
+        self.callbackQueue = callbackQueue ?? .main
     }
-    
-    public func add(transition: Transition) {
+
+    public func add(transition: Transition<State, Event>) {
         lockQueue.sync {
             let transitions = self.transitionsByEvent[transition.event]
             if transitions == nil {
@@ -42,48 +42,48 @@ final public class StateMachine {
             }
         }
     }
-    
-    public func process(event: String, callback: TransitionBlock? = nil) {
-        var transitions: [Transition]?
+
+    public func process(event: Event, callback: TransitionBlock? = nil) {
+        var transitions: [Transition<State, Event>]?
         lockQueue.sync {
             transitions = self.transitionsByEvent[event]
         }
-        
+
         workingQueue.async {
             let performableTransitions = transitions?.filter { return $0.source == self.internalCurrentState } ?? []
-            
+
             if performableTransitions.count == 0 {
                 self.callbackQueue.async {
                     callback?(.failure)
                 }
                 return
             }
-            
+
             for transition in performableTransitions {
                 self.log(message: "[Stateful 🦜]: Processing event '\(event)' from '\(self.internalCurrentState)'")
                 self.callbackQueue.async {
                     transition.executePreBlock()
                 }
-                
+
                 self.log(message: "[Stateful 🦜]: Processed pre condition for event '\(event)' from '\(transition.source)' to '\(transition.destination)'")
-                
+
                 let previousState = self.internalCurrentState
                 self.internalCurrentState = transition.destination
-                
+
                 self.log(message: "[Stateful 🦜]: Processed state change from '\(previousState)' to '\(transition.destination)'")
                 self.callbackQueue.async {
                     transition.executePostBlock()
                 }
-                
+
                 self.log(message: "[Stateful 🦜]: Processed post condition for event '\(event)' from '\(transition.source)' to '\(transition.destination)'")
-                
+
                 self.callbackQueue.async {
                     callback?(.success)
                 }
             }
         }
     }
-    
+
     private func log(message: String) {
         if self.enableLogging {
             print(message)

--- a/Stateful/Classes/Transition.swift
+++ b/Stateful/Classes/Transition.swift
@@ -15,17 +15,17 @@ public enum TrasitionResult {
 public typealias ExecutionBlock = (() -> Void)
 public typealias TransitionBlock = ((TrasitionResult) -> Void)
 
-public struct Transition {
-    
-    public let event: String
-    public let source: String
-    public let destination: String
+public struct Transition<State, Event> {
+
+    public let event: Event
+    public let source: State
+    public let destination: State
     let preBlock: ExecutionBlock?
     let postBlock: ExecutionBlock?
-    
-    public init(with event: String,
-                from: String,
-                to: String,
+
+    public init(with event: Event,
+                from: State,
+                to: State,
                 preBlock: ExecutionBlock? = nil,
                 postBlock: ExecutionBlock? = nil) {
         self.event = event
@@ -34,11 +34,11 @@ public struct Transition {
         self.preBlock = preBlock
         self.postBlock = postBlock
     }
-    
+
     func executePreBlock() {
         preBlock?()
     }
-    
+
     func executePostBlock() {
         postBlock?()
     }

--- a/Stateful/UnitTests/StateMachineTests.swift
+++ b/Stateful/UnitTests/StateMachineTests.swift
@@ -9,12 +9,27 @@ import XCTest
 @testable import Stateful
 
 class aTests: XCTestCase {
-    
-    var stateMachine: StateMachine!
+
+    typealias TransitionDefault = Transition<StateType, EventType>
+    typealias StateMachineDefault = StateMachine<StateType, EventType>
+
+    enum EventType {
+        case e1
+        case e2
+    }
+
+    enum StateType {
+        case idle
+        case started
+        case running
+        case completed
+    }
+
+    var stateMachine: StateMachine<StateType, EventType>!
     
     override func setUp() {
         super.setUp()
-        stateMachine = StateMachine(initialState: "idle")
+        stateMachine = StateMachineDefault(initialState: .idle)
         stateMachine.enableLogging = true
     }
     
@@ -24,37 +39,37 @@ class aTests: XCTestCase {
     }
     
     func test_Creation() {
-        XCTAssertEqual(stateMachine.currentState, "idle")
+        XCTAssertEqual(stateMachine.currentState, .idle)
     }
     
     func test_ProcessingSingleTransition() {
-        stateMachine.process(event: "e1")
-        XCTAssertEqual(stateMachine.currentState, "idle")
+        stateMachine.process(event: .e1)
+        XCTAssertEqual(stateMachine.currentState, .idle)
         
-        let transition = Transition(with: "e1", from: "idle", to: "started")
+        let transition = TransitionDefault(with: .e1, from: .idle, to: .started)
         stateMachine.add(transition: transition)
-        stateMachine.process(event: "e1")
-        XCTAssertEqual(stateMachine.currentState, "started")
+        stateMachine.process(event: .e1)
+        XCTAssertEqual(stateMachine.currentState, .started)
     }
     
     func test_MultipleTransistionsWithSameEvent() {
-        stateMachine.process(event: "e1")
-        XCTAssertEqual(stateMachine.currentState, "idle")
+        stateMachine.process(event: .e1)
+        XCTAssertEqual(stateMachine.currentState, .idle)
         
-        let transition1 = Transition(with: "e1", from: "idle", to: "started")
+        let transition1 = TransitionDefault(with: .e1, from: .idle, to: .started)
         stateMachine.add(transition: transition1)
-        let transition2 = Transition(with: "e2", from: "started", to: "idle")
+        let transition2 = TransitionDefault(with: .e2, from: .started, to: .idle)
         stateMachine.add(transition: transition2)
-        let transition3 = Transition(with: "e1", from: "started", to: "idle")
+        let transition3 = TransitionDefault(with: .e1, from: .started, to: .idle)
         stateMachine.add(transition: transition3)
         
-        stateMachine.process(event: "e1")
-        XCTAssertEqual(stateMachine.currentState, "started")
-        stateMachine.process(event: "e2")
-        XCTAssertEqual(stateMachine.currentState, "idle")
-        stateMachine.process(event: "e1")
-        XCTAssertEqual(stateMachine.currentState, "started")
-        stateMachine.process(event: "e1")
-        XCTAssertEqual(stateMachine.currentState, "idle")
+        stateMachine.process(event: .e1)
+        XCTAssertEqual(stateMachine.currentState, .started)
+        stateMachine.process(event: .e2)
+        XCTAssertEqual(stateMachine.currentState, .idle)
+        stateMachine.process(event: .e1)
+        XCTAssertEqual(stateMachine.currentState, .started)
+        stateMachine.process(event: .e1)
+        XCTAssertEqual(stateMachine.currentState, .idle)
     }
 }


### PR DESCRIPTION
I bet there is a reason behind it, so it's JUSTanidea. But I think this small change helps keeping everything together by avoiding all those `rawValue`s and having to go through state changes with strings.
Just consider swapping a state with an event, spelling them wrong, etc..

Anyway, thanks for the cool code!